### PR TITLE
update .npmignore to fix permissions

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 .npmignore
+.git
 .gitignore
 node_modules


### PR DESCRIPTION
This error pops out when installing packages after installing this one:

``` 
EISGIT: groupme: Appears to be a git repo or submodule. Refusing to remove it. 
Update manually, or move it out of the way first.
```
Adding `.git` to `.npmignore` fixes this problem.